### PR TITLE
Specify dep version in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,5 +17,10 @@ setup(
     log_description=README,
     long_description_content_type="text/markdown",
     include_package_data=True,
-    install_requires=["xmlschema", "validators", "Cerberus", "pathvalidate"]
+    install_requires=[
+        "xmlschema>=1.3.1", 
+        "validators>=0.18.1", 
+        "Cerberus>=1.3.2", 
+        "pathvalidate>=2.3.1"
+    ]
 )


### PR DESCRIPTION
This PR adds minimum version specifiers to the setup.py to ensure that the install environment supports odmlib